### PR TITLE
add functionality to enable players name to show on board when clicke…

### DIFF
--- a/src/game_board.py
+++ b/src/game_board.py
@@ -1,158 +1,171 @@
 # TODO *must* reference tic-tac-toe game
 #  ref https://github.com/abhishek305/Tic-Tac-Toe-Game-in-python-3-Tkinter/blob/master/my%20tic%20tac%202.py
-def board_square_click(playerName, button):
-    if button['text'] == ' ':
-        button['text'] = playerName
+import re
+
+
+def board_square_click(players, turn, button):
+    board_labels = {'Roll Again', 'CENTER', 'RED', 'WHITE', 'GREEN', 'BLUE'}
+    if button['text'] == ' ' and not (button['text'] in board_labels):
+        button['text'] = players[turn.player_turn].name
         # TODO add logic here to identify which question to pull up
         # TODO this can be done using the background color
         # print(button['highlightbackground'])
         # print(color_enum.ORANGE.name.lower())
         # print(color_enum.ORANGE.color)
-
-    elif button['text'] != ' ':
+    elif button['text'] in board_labels:
+        button['text'] = '{}{}\n{}'.format('*', button['text'], players[turn.player_turn].name)
+    elif button['text'] != ' ' and (button['text'].startswith('*')):
+        button['text'] = re.sub(r'^{0}'.format(re.escape('*')), '', button['text']).split('\n')[0]
+    elif button['text'] != ' ' and not (button['text'].startswith('*') and button['text'] in board_labels):
         button['text'] = ' '
 
 
 # TODO create a player object so that it can be passed to command=
-def create_game_board(tk_button, root_window, font_type, start_row, sq_dim, color_enum, player1):
+def create_game_board(tk_button, root_window, font_type, start_row, sq_dim, color_enum, players_dict, turn):
     # row 1
     row1_sq1 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.RED.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(player1.get(), row1_sq1))  # dummy code to show functionality
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row1_sq1))
     row1_sq1.grid(row=start_row, column=1)
 
     row1_sq2 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.WHITE.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row1_sq2))
     row1_sq2.grid(row=start_row, column=2)
 
     row1_sq3 = tk_button(root_window, text='Roll Again', font=font_type,
-                         highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim)
+                         highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, turn, row1_sq3))
     row1_sq3.grid(row=start_row, column=3)
 
     row1_sq4 = tk_button(root_window, text='RED', font=font_type, highlightbackground=color_enum.RED.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row1_sq4))
     row1_sq4.grid(row=start_row, column=4)
 
     row1_sq5 = tk_button(root_window, text='Roll Again', font=font_type,
-                         highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim)
+                         highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, turn, row1_sq5))
     row1_sq5.grid(row=start_row, column=5)
 
     row1_sq6 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.WHITE.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row1_sq6))
     row1_sq6.grid(row=start_row, column=6)
 
     row1_sq7 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.BLUE.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row1_sq7))
     row1_sq7.grid(row=start_row, column=7)
 
     # row 2
     row2_sq1 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.BLUE.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row2_sq1))
     row2_sq1.grid(row=start_row + 1, column=1)
 
     row2_sq4 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.WHITE.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row2_sq4))
     row2_sq4.grid(row=start_row + 1, column=4)
 
     row2_sq7 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.GREEN.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row2_sq7))
     row2_sq7.grid(row=start_row + 1, column=7)
 
     # row 3
     row3_sq1 = tk_button(root_window, text='Roll Again', font=font_type,
-                         highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim)
+                         highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, turn, row3_sq1))
     row3_sq1.grid(row=start_row + 2, column=1)
 
     row3_sq4 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.BLUE.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row3_sq4))
     row3_sq4.grid(row=start_row + 2, column=4)
 
     row3_sq7 = tk_button(root_window, text='Roll Again', font=font_type,
-                         highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim)
+                         highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, turn, row3_sq7))
     row3_sq7.grid(row=start_row + 2, column=7)
 
     # row 4 - with center square
     row4_sq1 = tk_button(root_window, text='GREEN', font=font_type, highlightbackground=color_enum.GREEN.description,
-                         height=sq_dim,
-                         width=sq_dim)  # dummy code to show functionality
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row4_sq1))
     row4_sq1.grid(row=start_row + 3, column=1)
 
     row4_sq2 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.RED.description,
-                         height=sq_dim,
-                         width=sq_dim)  # dummy code to show functionality
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row4_sq2))
     row4_sq2.grid(row=start_row + 3, column=2)
 
     row4_sq3 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.WHITE.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row4_sq3))
     row4_sq3.grid(row=start_row + 3, column=3)
 
-    row4_sq4 = tk_button(root_window, text='CENTER\nSQUARE', font=font_type,
-                         highlightbackground=color_enum.PURPLE.description, height=sq_dim,
-                         width=sq_dim)
+    row4_sq4 = tk_button(root_window, text='CENTER', font=font_type,
+                         highlightbackground=color_enum.PURPLE.description, height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, turn, row4_sq4))
     row4_sq4.grid(row=start_row + 3, column=4)
 
     row4_sq5 = tk_button(root_window, text='  ', font=font_type, highlightbackground=color_enum.GREEN.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row4_sq5))
     row4_sq5.grid(row=start_row + 3, column=5)
 
     row4_sq6 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.BLUE.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row4_sq6))
     row4_sq6.grid(row=start_row + 3, column=6)
 
     row4_sq7 = tk_button(root_window, text='WHITE', font=font_type, highlightbackground=color_enum.WHITE.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row4_sq7))
     row4_sq7.grid(row=start_row + 3, column=7)
 
     # row 5
     row5_sq1 = tk_button(root_window, text='Roll Again', font=font_type,
-                         highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim)
+                         highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, turn, row5_sq1))
     row5_sq1.grid(row=start_row + 4, column=1)
 
     row5_sq4 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.RED.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row5_sq4))
     row5_sq4.grid(row=start_row + 4, column=4)
 
     row5_sq7 = tk_button(root_window, text='Roll Again', font=font_type,
-                         highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim)
+                         highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, turn, row5_sq7))
     row5_sq7.grid(row=start_row + 4, column=7)
 
     # row 6
     row6_sq1 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.WHITE.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row6_sq1))
     row6_sq1.grid(row=start_row + 5, column=1)
 
     row6_sq4 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.GREEN.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row6_sq4))
     row6_sq4.grid(row=start_row + 5, column=4)
 
     row6_sq7 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.GREEN.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row6_sq7))
     row6_sq7.grid(row=start_row + 5, column=7)
 
     # row 7
     row7_sq1 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.RED.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row7_sq1))
     row7_sq1.grid(row=start_row + 6, column=1)
 
     row7_sq2 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.GREEN.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row7_sq2))
     row7_sq2.grid(row=start_row + 6, column=2)
 
     row7_sq3 = tk_button(root_window, text='Roll Again', font=font_type,
-                         highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim)
+                         highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, turn, row7_sq3))
     row7_sq3.grid(row=start_row + 6, column=3)
 
     row7_sq4 = tk_button(root_window, text='BLUE', font=font_type, highlightbackground=color_enum.BLUE.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row7_sq4))
     row7_sq4.grid(row=start_row + 6, column=4)
 
     row7_sq5 = tk_button(root_window, text='Roll Again', font=font_type,
-                         highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim)
+                         highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, turn, row7_sq5))
     row7_sq5.grid(row=start_row + 6, column=5)
 
     row7_sq6 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.BLUE.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row7_sq6))
     row7_sq6.grid(row=start_row + 6, column=6)
 
     row7_sq7 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.RED.description,
-                         height=sq_dim, width=sq_dim)
+                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row7_sq7))
     row7_sq7.grid(row=start_row + 6, column=7)

--- a/src/game_board.py
+++ b/src/game_board.py
@@ -3,7 +3,16 @@
 import re
 
 
-def board_square_click(players, turn, button):
+def add_player_names_to_player_objects(players, names):
+    for key in players:
+        this_player = players[key]
+        this_name = names[key].get()
+        if this_name != '':
+            this_player.name = this_name
+
+
+def board_square_click(players, names, turn, button):
+    add_player_names_to_player_objects(players, names)
     board_labels = {'Roll Again', 'CENTER', 'RED', 'WHITE', 'GREEN', 'BLUE'}
     if button['text'] == ' ' and not (button['text'] in board_labels):
         button['text'] = players[turn.player_turn].name
@@ -20,152 +29,175 @@ def board_square_click(players, turn, button):
         button['text'] = ' '
 
 
-# TODO create a player object so that it can be passed to command=
-def create_game_board(tk_button, root_window, font_type, start_row, sq_dim, color_enum, players_dict, turn):
+def create_game_board(tk_button, root_window, font_type, start_row, sq_dim, color_enum, players_dict, names_dict, turn):
     # row 1
     row1_sq1 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.RED.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row1_sq1))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row1_sq1))
     row1_sq1.grid(row=start_row, column=1)
 
     row1_sq2 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.WHITE.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row1_sq2))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row1_sq2))
     row1_sq2.grid(row=start_row, column=2)
 
     row1_sq3 = tk_button(root_window, text='Roll Again', font=font_type,
                          highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim,
-                         command=lambda: board_square_click(players_dict, turn, row1_sq3))
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row1_sq3))
     row1_sq3.grid(row=start_row, column=3)
 
     row1_sq4 = tk_button(root_window, text='RED', font=font_type, highlightbackground=color_enum.RED.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row1_sq4))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row1_sq4))
     row1_sq4.grid(row=start_row, column=4)
 
     row1_sq5 = tk_button(root_window, text='Roll Again', font=font_type,
                          highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim,
-                         command=lambda: board_square_click(players_dict, turn, row1_sq5))
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row1_sq5))
     row1_sq5.grid(row=start_row, column=5)
 
     row1_sq6 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.WHITE.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row1_sq6))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row1_sq6))
     row1_sq6.grid(row=start_row, column=6)
 
     row1_sq7 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.BLUE.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row1_sq7))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row1_sq7))
     row1_sq7.grid(row=start_row, column=7)
 
     # row 2
     row2_sq1 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.BLUE.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row2_sq1))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row2_sq1))
     row2_sq1.grid(row=start_row + 1, column=1)
 
     row2_sq4 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.WHITE.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row2_sq4))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row2_sq4))
     row2_sq4.grid(row=start_row + 1, column=4)
 
     row2_sq7 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.GREEN.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row2_sq7))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row2_sq7))
     row2_sq7.grid(row=start_row + 1, column=7)
 
     # row 3
     row3_sq1 = tk_button(root_window, text='Roll Again', font=font_type,
                          highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim,
-                         command=lambda: board_square_click(players_dict, turn, row3_sq1))
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row3_sq1))
     row3_sq1.grid(row=start_row + 2, column=1)
 
     row3_sq4 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.BLUE.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row3_sq4))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row3_sq4))
     row3_sq4.grid(row=start_row + 2, column=4)
 
     row3_sq7 = tk_button(root_window, text='Roll Again', font=font_type,
                          highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim,
-                         command=lambda: board_square_click(players_dict, turn, row3_sq7))
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row3_sq7))
     row3_sq7.grid(row=start_row + 2, column=7)
 
     # row 4 - with center square
     row4_sq1 = tk_button(root_window, text='GREEN', font=font_type, highlightbackground=color_enum.GREEN.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row4_sq1))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row4_sq1))
     row4_sq1.grid(row=start_row + 3, column=1)
 
     row4_sq2 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.RED.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row4_sq2))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row4_sq2))
     row4_sq2.grid(row=start_row + 3, column=2)
 
     row4_sq3 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.WHITE.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row4_sq3))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row4_sq3))
     row4_sq3.grid(row=start_row + 3, column=3)
 
     row4_sq4 = tk_button(root_window, text='CENTER', font=font_type,
                          highlightbackground=color_enum.PURPLE.description, height=sq_dim, width=sq_dim,
-                         command=lambda: board_square_click(players_dict, turn, row4_sq4))
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row4_sq4))
     row4_sq4.grid(row=start_row + 3, column=4)
 
     row4_sq5 = tk_button(root_window, text='  ', font=font_type, highlightbackground=color_enum.GREEN.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row4_sq5))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row4_sq5))
     row4_sq5.grid(row=start_row + 3, column=5)
 
     row4_sq6 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.BLUE.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row4_sq6))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row4_sq6))
     row4_sq6.grid(row=start_row + 3, column=6)
 
     row4_sq7 = tk_button(root_window, text='WHITE', font=font_type, highlightbackground=color_enum.WHITE.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row4_sq7))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row4_sq7))
     row4_sq7.grid(row=start_row + 3, column=7)
 
     # row 5
     row5_sq1 = tk_button(root_window, text='Roll Again', font=font_type,
                          highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim,
-                         command=lambda: board_square_click(players_dict, turn, row5_sq1))
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row5_sq1))
     row5_sq1.grid(row=start_row + 4, column=1)
 
     row5_sq4 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.RED.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row5_sq4))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row5_sq4))
     row5_sq4.grid(row=start_row + 4, column=4)
 
     row5_sq7 = tk_button(root_window, text='Roll Again', font=font_type,
                          highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim,
-                         command=lambda: board_square_click(players_dict, turn, row5_sq7))
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row5_sq7))
     row5_sq7.grid(row=start_row + 4, column=7)
 
     # row 6
     row6_sq1 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.WHITE.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row6_sq1))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row6_sq1))
     row6_sq1.grid(row=start_row + 5, column=1)
 
     row6_sq4 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.GREEN.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row6_sq4))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row6_sq4))
     row6_sq4.grid(row=start_row + 5, column=4)
 
     row6_sq7 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.GREEN.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row6_sq7))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row6_sq7))
     row6_sq7.grid(row=start_row + 5, column=7)
 
     # row 7
     row7_sq1 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.RED.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row7_sq1))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row7_sq1))
     row7_sq1.grid(row=start_row + 6, column=1)
 
     row7_sq2 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.GREEN.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row7_sq2))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row7_sq2))
     row7_sq2.grid(row=start_row + 6, column=2)
 
     row7_sq3 = tk_button(root_window, text='Roll Again', font=font_type,
                          highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim,
-                         command=lambda: board_square_click(players_dict, turn, row7_sq3))
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row7_sq3))
     row7_sq3.grid(row=start_row + 6, column=3)
 
     row7_sq4 = tk_button(root_window, text='BLUE', font=font_type, highlightbackground=color_enum.BLUE.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row7_sq4))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row7_sq4))
     row7_sq4.grid(row=start_row + 6, column=4)
 
     row7_sq5 = tk_button(root_window, text='Roll Again', font=font_type,
                          highlightbackground=color_enum.ORANGE.description, height=sq_dim, width=sq_dim,
-                         command=lambda: board_square_click(players_dict, turn, row7_sq5))
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row7_sq5))
     row7_sq5.grid(row=start_row + 6, column=5)
 
     row7_sq6 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.BLUE.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row7_sq6))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row7_sq6))
     row7_sq6.grid(row=start_row + 6, column=6)
 
     row7_sq7 = tk_button(root_window, text=' ', font=font_type, highlightbackground=color_enum.RED.description,
-                         height=sq_dim, width=sq_dim, command=lambda: board_square_click(players_dict, turn, row7_sq7))
+                         height=sq_dim, width=sq_dim,
+                         command=lambda: board_square_click(players_dict, names_dict, turn, row7_sq7))
     row7_sq7.grid(row=start_row + 6, column=7)

--- a/src/main_view.py
+++ b/src/main_view.py
@@ -4,6 +4,8 @@ from tkinter.font import Font
 from src.die_roll import roll_die
 from src.game_board import create_game_board
 from src.models.Color import Color
+from src.models.Player import Player
+from src.models.Turn import Turn
 
 root = Tk()
 root.title("Trivial Purfuit by Software Titans")
@@ -26,6 +28,20 @@ player3_name = Entry(root, textvariable=player3, bd=5)
 player3_name.grid(row=3, column=1, columnspan=8, sticky='w')
 player4_name = Entry(root, textvariable=player4, bd=5)
 player4_name.grid(row=4, column=1, columnspan=8, sticky='w')
+
+# instantiate players, turn and player objects
+turn = Turn()
+p1 = Player('player1')
+p2 = Player('player2')
+p3 = Player('player3')
+p4 = Player('player4')
+
+players = {
+    1: p1,
+    2: p2,
+    3: p3,
+    4: p4
+}
 
 # player name labels
 label_p1 = Label(root, text="Player 1:", font=helvetica_20, bg=Color.YELLOW.description, fg=Color.BLACK.description,
@@ -64,7 +80,8 @@ label_p4s.grid(row=4, column=5, sticky='e')
 # die roll
 die_label = Label(root, text=' ', font=helvetica_60)
 die_label.grid(row=5, column=2, sticky='e')
-die_button = Button(root, text='Roll Die', font=helvetica_20, fg=Color.BLACK.description, command=lambda: roll_die(die_label))
+die_button = Button(root, text='Roll Die', font=helvetica_20, fg=Color.BLACK.description,
+                    command=lambda: roll_die(die_label))
 die_button.grid(row=5, column=1, sticky='e')
 
 # create the game board
@@ -78,6 +95,8 @@ create_game_board(
     start_row=start_row,
     sq_dim=sq_dim,
     color_enum=Color,
-    player1=player1)
+    players_dict=players,
+    turn=turn
+)
 
 root.mainloop()

--- a/src/main_view.py
+++ b/src/main_view.py
@@ -36,6 +36,13 @@ p2 = Player('player2')
 p3 = Player('player3')
 p4 = Player('player4')
 
+names = {
+    1: player1,
+    2: player2,
+    3: player3,
+    4: player4
+}
+
 players = {
     1: p1,
     2: p2,
@@ -95,6 +102,7 @@ create_game_board(
     start_row=start_row,
     sq_dim=sq_dim,
     color_enum=Color,
+    names_dict=names,
     players_dict=players,
     turn=turn
 )

--- a/src/models/Player.py
+++ b/src/models/Player.py
@@ -1,3 +1,11 @@
 class Player(object):
     def __init__(self, name):
-        self.name = name
+        self._name = name
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        self._name = name

--- a/src/models/Player.py
+++ b/src/models/Player.py
@@ -1,27 +1,3 @@
 class Player(object):
     def __init__(self, name):
         self.name = name
-
-class Protective(object):
-    """protected property demo"""
-    #
-    def __init__(self, start_protected_value=0):
-        self.protected_value = start_protected_value
-    #
-    @property
-    def protected_value(self):
-        return self._protected_value
-    #
-    @protected_value.setter
-    def protected_value(self, value):
-        if value != int(value):
-            raise TypeError("protected_value must be an integer")
-        if 0 <= value <= 100:
-            self._protected_value = int(value)
-        else:
-            raise ValueError("protected_value must be " +
-                             "between 0 and 100 inclusive")
-    #
-    @protected_value.deleter
-    def protected_value(self):
-        raise AttributeError("do not delete, protected_value can be set to 0")


### PR DESCRIPTION
…d and then be removed and replaces with whatever was originally there

_To test_: Click on any square on the board and it will be replaced by `player1` when you unclick the square, it will be replaced by whatever was originally there. To customize player names, add a player name to `Player 1` and then click and unclick any square. The square should shows the player name entered

![triv-board-sq-name1](https://user-images.githubusercontent.com/12648820/86135537-f5def580-bab8-11ea-8c35-4d094d0eeb41.gif)

