### PR TITLE
add current turn display and start game functionality

### DIFF
--- a/src/die_roll_view.py
+++ b/src/die_roll_view.py
@@ -8,6 +8,7 @@ The code for using unicode for die faces is from groundhogday321. “groundhogda
 GitHub, github.com/groundhogday321/python-tkinter-roll-dice-gui/blob/master/tkinter roll dice.py.
 """
 
+die_button = ''
 
 def roll_die(tk_label):
     """
@@ -28,10 +29,24 @@ def create_die_roll(tk, frame):
     :param tk: Object representing Tkinter
     :param frame: Tkinter Frame object
     """
+
+    global die_button
+
     die_label = tk.Label(frame, text=' ', font=Font(family='Helvetica', size=90, weight='bold'),
                          bg=Color.LIGHT_GREEN.description)
     die_label.grid(row=5, column=2, sticky=tk.NE)
     die_button = tk.Button(frame, text='Roll Die', font=Font(family='Helvetica', size=20, weight='bold'),
                            fg=Color.BLACK.description, bg=Color.LIGHT_GREEN.description,
-                           command=lambda: roll_die(die_label))
+                           command=lambda: roll_die(die_label), state='disabled')
     die_button.grid(row=5, column=1, sticky=tk.E)
+
+def enable_die_roll():
+    """
+    Method to enable die roll and begin game
+    """
+
+    global die_button
+
+    die_button.config(state='normal')
+
+

--- a/src/entry_view.py
+++ b/src/entry_view.py
@@ -1,5 +1,7 @@
 from src.models.Color import Color
+import tkinter as tk
 
+frame = ''
 
 def create_entry_view(tk, entry_frame):
     """
@@ -8,25 +10,59 @@ def create_entry_view(tk, entry_frame):
     :param tk: Object representing Tkinter
     :param entry_frame: Tkinter Frame object
     """
+
+    global frame
+
+    frame = entry_frame;
+
     helvetica_20 = tk.font.Font(family='Helvetica', size=20, weight='bold')
 
     # player name labels
-    label_p1 = tk.Label(entry_frame, text="Player 1:", font=helvetica_20, bg=Color.YELLOW.description,
+    label_p1 = tk.Label(frame, text="Player 1:", font=helvetica_20, bg=Color.YELLOW.description,
                         fg=Color.BLACK.description,
                         height=1, width=8)
     label_p1.grid(row=1, column=0, sticky='e')
 
-    label_p2 = tk.Label(entry_frame, text="Player 2:", font=helvetica_20, bg=Color.YELLOW.description,
+    label_p2 = tk.Label(frame, text="Player 2:", font=helvetica_20, bg=Color.YELLOW.description,
                         fg=Color.BLACK.description,
                         height=1, width=8)
     label_p2.grid(row=2, column=0, sticky='e')
 
-    label_p3 = tk.Label(entry_frame, text="Player 3:", font=helvetica_20, bg=Color.YELLOW.description,
+    label_p3 = tk.Label(frame, text="Player 3:", font=helvetica_20, bg=Color.YELLOW.description,
                         fg=Color.BLACK.description,
                         height=1, width=8)
     label_p3.grid(row=3, column=0, sticky='e')
 
-    label_p4 = tk.Label(entry_frame, text="Player 4:", font=helvetica_20, bg=Color.YELLOW.description,
+    label_p4 = tk.Label(frame, text="Player 4:", font=helvetica_20, bg=Color.YELLOW.description,
                         fg=Color.BLACK.description,
                         height=1, width=8)
     label_p4.grid(row=4, column=0, sticky='e')
+
+    # current turn label
+    label_turn = tk.Label(frame, text="Current Player Turn is:", font=helvetica_20, bg=Color.LIGHT_BLUE.description,
+                        fg=Color.BLACK.description,
+                        height=1, width=20)
+    label_turn.grid(row=6, column=1, sticky='e')
+
+def update_turn(players, turn):
+    """
+    Method to update which player turn
+
+    :param players: dict of all players with keys being 1, 2, 3, 4
+    :type: dict of Player objects
+    :param turn: The current player as represented by Turn object
+    :type: Turn object
+    """
+    global frame
+
+    helvetica_20 = tk.font.Font(family='Helvetica', size=20, weight='bold')
+
+    current_turn = tk.Label(frame, text=players[turn.player_turn].name, font=helvetica_20,
+                            bg=Color.LIGHT_BLUE.description,
+                            fg=Color.BLACK.description,
+                            height=1, width=8)
+    current_turn.grid(row=6, column=2, sticky='e')
+
+
+
+

--- a/src/game_board_view.py
+++ b/src/game_board_view.py
@@ -9,23 +9,7 @@ The button system for our board game was inspired by abhishek305. “abhishek305
 GitHub, github.com/abhishek305/Tic-Tac-Toe-Game-in-python-3-Tkinter/blob/master/my tic tac 2.py.
 """
 
-
-def add_player_names_to_player_objects(players, names):
-    """
-    Method to player names to the Player object. This method is triggered by a lambda function so checks to see if
-    player name is updated in the entry view
-
-    :param players: dict of all players with keys being 1, 2, 3, 4
-    :type: dict of Player objects
-    :param names: dict of player names with keys being 1, 2, 3, 4
-    :type: dict of str
-    """
-    for key in players:
-        this_player = players[key]
-        this_name = names[key].get()
-        if this_name != '':
-            this_player.name = this_name
-
+frame = ''
 
 def board_square_click(players, names, turn, button, tk_label, tk_button, question_bank):
     """
@@ -43,7 +27,7 @@ def board_square_click(players, names, turn, button, tk_label, tk_button, questi
     :type: Button
     :return:
     """
-    add_player_names_to_player_objects(players, names)
+
     board_labels = {'Roll Again', 'CENTER', config('CATEGORY1_COLOR').upper() , config('CATEGORY2_COLOR').upper(), config('CATEGORY3_COLOR').upper(), config('CATEGORY4_COLOR').upper()}
     if button['text'] == ' ' and not (button['text'] in board_labels):
         button['text'] = players[turn.player_turn].name
@@ -56,13 +40,13 @@ def board_square_click(players, names, turn, button, tk_label, tk_button, questi
         display_question(Color.return_color_from_hex(button['highlightbackground']), tk_label, tk_button, question_bank, players, turn, button['text'])
     elif button['text'] != ' ' and (button['text'].startswith('*')):
         button['text'] = re.sub(r'^{0}'.format(re.escape('*')), '', button['text']).split('\n')[0]
-        display_question(Color.return_color_from_hex(button['highlightbackground']), tk_label, tk_button, question_bank, players, turn, button['text'])
+        #display_question(Color.return_color_from_hex(button['highlightbackground']), tk_label, tk_button, question_bank, players, turn, button['text'])
     elif button['text'] != ' ' and not (button['text'].startswith('*') and button['text'] in board_labels):
         button['text'] = ' '
-        display_question(Color.return_color_from_hex(button['highlightbackground']), tk_label, tk_button, question_bank, players, turn, button['text'])
+        #display_question(Color.return_color_from_hex(button['highlightbackground']), tk_label, tk_button, question_bank, players, turn, button['text'])
 
 
-def create_game_board(tk_button, frame, question_label, font_type, start_row, sq_dim, players, names, turn,
+def create_game_board(tk_button, board_frame, question_label, font_type, start_row, sq_dim, players, names, turn,
                       question_button, question_bank):
     """
     Method representing the board game view. Each row and button is individually created.
@@ -72,7 +56,7 @@ def create_game_board(tk_button, frame, question_label, font_type, start_row, sq
     :param question_button: 
     :param tk_button: Tkinter Button object
     :type: Button
-    :param frame: The Frame in which to create the game board
+    :param board_frame: The Frame in which to create the game board
     :type: Frame
     :param question_label: The Label containing the currently displayed question
     :type: Label
@@ -89,6 +73,11 @@ def create_game_board(tk_button, frame, question_label, font_type, start_row, sq
     :param turn: The current player as represented by Turn object
     :type: Turn object
     """
+
+    global frame
+
+    frame = board_frame;
+
     # row 1
     row1_sq1 = tk_button(frame, text=' ', font=font_type,
                          highlightbackground=Color.return_hex_from_color(config('CATEGORY1_COLOR')),
@@ -385,3 +374,8 @@ def display_question(color_type, tk_label, tk_button, question_bank, players, tu
             tk_label.configure(text=' ')
     except AttributeError:
         print("issue fetching question")
+
+def enable_game_board():
+    global frame
+    for child in frame.winfo_children():
+        child.configure(state='normal')

--- a/src/main_view.py
+++ b/src/main_view.py
@@ -1,7 +1,7 @@
 import tkinter as tk
-from src.die_roll_view import create_die_roll
+from src.die_roll_view import create_die_roll, enable_die_roll
 from src.file_io import load_question_files
-from src.game_board_view import create_game_board
+from src.game_board_view import create_game_board, enable_game_board
 from src.models.Color import Color
 from src.models.Player import Player
 from src.models.Turn import Turn
@@ -9,7 +9,7 @@ from src.models.Question import Question
 from tkinter.font import Font
 from decouple import config
 
-from src.entry_view import create_entry_view
+from src.entry_view import create_entry_view, update_turn
 from src.question_view import create_question_view
 
 """
@@ -21,7 +21,6 @@ Stack Overflow, 1 Nov. 1966, stackoverflow.com/a/49681192/4882806.
 ROWS, COLUMNS = 25, 25  # size of grid
 DISPLAY_ROWS = 10  # number of rows to display
 DISPLAY_COLUMNS = 25  # number of columns to display
-
 
 class TrivialPurfuit(tk.Tk):
     """
@@ -50,7 +49,8 @@ class TrivialPurfuit(tk.Tk):
         frame_entry.grid(row=3, column=0, sticky=tk.NW)
 
         # add canvas to this name entry frame
-        canvas_entry = tk.Canvas(frame_entry, bg=Color.LIGHT_GREEN.description, borderwidth=0, highlightthickness=0)
+        canvas_entry = tk.Canvas(frame_entry, bg=Color.LIGHT_GREEN.description, borderwidth=0, highlightthickness=0,
+                                 width=700)
         canvas_entry.grid(row=0, column=0)
 
         entry_frame = tk.Frame(canvas_entry, bg=Color.LIGHT_GREEN.description, bd=1)
@@ -61,7 +61,7 @@ class TrivialPurfuit(tk.Tk):
 
         # Add canvas to the question view frame
         question_view_canvas = tk.Canvas(question_view, bg=Color.LIGHT_GREEN.description, borderwidth=0,
-                                         highlightthickness=0)
+                                         highlightthickness=0, width=500)
         question_view_canvas.grid(row=0, column=0)
 
         question_frame = tk.Frame(question_view_canvas, bg=Color.LIGHT_GREEN.description, bd=1)
@@ -80,6 +80,14 @@ class TrivialPurfuit(tk.Tk):
         player3_name.grid(row=3, column=1, columnspan=8, sticky='w')
         player4_name = tk.Entry(entry_frame, textvariable=player4, bd=5)
         player4_name.grid(row=4, column=1, columnspan=8, sticky='w')
+
+        player_entries = [player1_name, player2_name, player3_name, player4_name]
+
+        # Initiate game start
+        start_game = tk.Button(entry_frame, text="Start Game", font=helvetica_20, bg=Color.LIGHT_GREEN.description,
+                               fg=Color.BLACK.description,
+                               command=lambda: begin_game(player_entries, players, names, turn))
+        start_game.grid(row=5, column=1, sticky='e')
 
         # instantiate question bank, players, turn and player objects
         question_files = [config('CATEGORY1_FILE'), config('CATEGORY2_FILE'),
@@ -181,7 +189,7 @@ class TrivialPurfuit(tk.Tk):
 
         create_game_board(
             tk_button=tk.Button,
-            frame=buttons_frame,
+            board_frame=buttons_frame,
             question_label=question_label,
             font_type=helvetica_20,
             start_row=0,
@@ -193,6 +201,9 @@ class TrivialPurfuit(tk.Tk):
             question_bank=question_bank
         )
 
+        for child in buttons_frame.winfo_children():
+            child.configure(state='disable')
+
         canvas_board_game.create_window((0, 0), window=buttons_frame, anchor=tk.NW)
 
         buttons_frame.update_idletasks()
@@ -203,6 +214,32 @@ class TrivialPurfuit(tk.Tk):
         dw, dh = int((w / COLUMNS) * DISPLAY_COLUMNS), int((h / ROWS) * DISPLAY_ROWS)
         canvas_board_game.configure(scrollregion=bbox, width=dw, height=dh)
 
+def begin_game(player_entries, players, names, turn):
+    """
+    Method to start game, lock in player names, enable die roll, enable game board
+
+    :param player_entries: array of player tk entries
+    :type: array of Tk Entry objects
+    :param players: dict of all players with keys being 1, 2, 3, 4
+    :type: dict of Player objects
+    :param names: dict of player names with keys being 1, 2, 3, 4
+    :type: dict of str
+    :param turn: The current player as represented by Turn object
+    :type: Turn object
+    """
+
+    for key in players:
+        this_player = players[key]
+        this_name = names[key].get()
+        if this_name != '':
+            this_player.name = this_name
+
+    for entry in player_entries:
+        entry.config(state='disable')
+
+    update_turn(players, turn)
+    enable_die_roll()
+    enable_game_board()
 
 if __name__ == "__main__":
     app = TrivialPurfuit("Trivial Purfuit by Software Titans")

--- a/src/question_view.py
+++ b/src/question_view.py
@@ -1,7 +1,7 @@
 from src.models.Color import Color
 from tkinter import messagebox
 from decouple import config
-
+from src.entry_view import update_turn
 
 def create_question_view(tk, question_frame, question_obj, players, turn, button_text):
     """
@@ -16,13 +16,13 @@ def create_question_view(tk, question_frame, question_obj, players, turn, button
 
     question_label = tk.Label(question_frame, text=question_obj.question,
                               font=helvetica_20, bg=Color.LIGHT_GREEN.description, fg=Color.BLACK.description,
-                              wraplength=200, justify='left')
+                              wraplength=400, justify='left')
     question_label.grid(row=0, column=0, sticky=tk.E)
 
     question_button = tk.Button(question_frame, text='Show Answer', font=helvetica_20, bg=Color.LIGHT_GREEN.description,
-                                fg=Color.BLACK.description, command=show_answer(question_obj, players, turn, button_text, button_text))
+                                fg=Color.BLACK.description, command=lambda: show_answer(question_obj, players, turn,
+                                button_text, button_text))
     question_button.grid(row=1, column=0, sticky=tk.W)
-    # question_button.configure(command=show_answer())
 
     return question_label, question_button
 
@@ -42,3 +42,4 @@ def show_answer(question_obj, players, turn, color_type, button_text):
                     players[turn.player_turn].slices.category4 = True
         else:
             turn.increment_player_turn(len(players))
+            update_turn(players, turn)


### PR DESCRIPTION
adding a start game button that will lock in (disable) player names and enable the game board and die roll - this made displaying current player turn easier

additionally, I expanded question view and prevented questions from being displayed for each button click on the board